### PR TITLE
Fix: white background

### DIFF
--- a/examples/emmy_noether.svg
+++ b/examples/emmy_noether.svg
@@ -2,8 +2,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
      width="1000" height="300" viewBox="0 0 1000 300">
 <style>
-svg {
-  background: white;
+rect.background {
+  fill: white;
 }
 path {
   stroke: black;
@@ -97,6 +97,7 @@ text.color_e_text {
   fill: #ffa600;
 }
 </style>
+<rect class="background" x="0" y="0" width="1000.0" height="300.0" />
 <g id="timeline_001">
   <path class="time_axis" d="M30.0,255.0 L970.0,255.0" />
   <g id="tics_001">

--- a/svg_timeline/style.py
+++ b/svg_timeline/style.py
@@ -47,8 +47,8 @@ class Colors(StrEnum):
 
 
 DEFAULT_CSS = {
-    'svg': {
-        'background': 'white',
+    'rect.background': {
+        'fill': 'white',
     },
     'path': {
         'stroke': 'black',

--- a/svg_timeline/timeline.py
+++ b/svg_timeline/timeline.py
@@ -19,6 +19,8 @@ class TimelinePlot:
                  size: tuple[int, int] = (800, 600)):
         self._width, self._height = size
         self._svg = SVG(self._width, self._height, style=DEFAULT_CSS)
+        # set a white background
+        self._svg.elements.append(Rectangle(Vector(0, 0), Vector(*size), classes=['background']))
 
         y = Defaults.arrow_y_position * self._height
         x1 = Defaults.arrow_x_padding * self._width


### PR DESCRIPTION
Some applications do not support the CSS property `background`. For compatibility, the background is now explicitly drawn as a white rectangle with the same dimensions as the canvas.